### PR TITLE
Drop database and delete user when a cluster is terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Install and configure databases/ stores for flex masters during installation. Th
 Usage
 --
 
+To install/ configure the database:
+
 ```bash
 $ docker run -e DB_HOST=localhost -e DB_MASTERUSERNAME=root -e DB_MASTERPASSWORD=$something -e DB_PASSWORD=$something_else -e CLUSTER_ID=test quay.io/financialtimes/flex-data
+```
+
+To cleanup the database and users when a cluster is torn down:
+
+```bash
+$ docker run -e DB_HOST=localhost -e DB_MASTERUSERNAME=root -e DB_MASTERPASSWORD=$something -e DB_PASSWORD=$something_else -e CLUSTER_ID=test BUILDOUT=teardown quay.io/financialtimes/flex-data
 ```

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -4,6 +4,8 @@ set -a
 set -x
 set -e
 
+: ${BUILDOUT:=install}
+
 : ${DB_HOST:localhost}
 : ${MONGO_HOST:localhost}
 
@@ -15,21 +17,30 @@ set -e
 
 : ${DB_PASSWORD:?}
 
-cat > /tmp/batch.sql <<EOF
-CREATE DATABASE IF NOT EXISTS ${CLUSTER_ID}_master ;
-GRANT ALL on ${CLUSTER_ID}_master.* to '${CLUSTER_ID}'@'%' IDENTIFIED BY '${DB_PASSWORD}' ;
-GRANT TRIGGER on ${CLUSTER_ID}_master.* to '${CLUSTER_ID}'@'%' ;
+if [[ "${BUILDOUT}" = 'install']]; then
+    cat > /tmp/batch.sql <<EOF
+    CREATE DATABASE IF NOT EXISTS ${CLUSTER_ID}_master ;
+    GRANT ALL on ${CLUSTER_ID}_master.* to '${CLUSTER_ID}'@'%' IDENTIFIED BY '${DB_PASSWORD}' ;
+    GRANT TRIGGER on ${CLUSTER_ID}_master.* to '${CLUSTER_ID}'@'%' ;
 
-FLUSH PRIVILEGES ;
+    FLUSH PRIVILEGES ;
 EOF
-
-cat > /tmp/batch.js <<EOF
-db.createUser({user:"${CLUSTER_ID}", pwd: "${DB_PASSWORD}", roles: [{role: "readWrite", db: "${CLUSTER_ID}"}] })
-sh.enableSharding("${CLUSTER_ID}")
+	cat > /tmp/batch.js <<EOF
+	db.createUser({user:"${CLUSTER_ID}", pwd: "${DB_PASSWORD}", roles: [{role: "readWrite", db: "${CLUSTER_ID}"}] })
+	sh.enableSharding("${CLUSTER_ID}")
 EOF
+elif [[ "${BUILDOUT}" = 'teardown']]; then
+    cat > /tmp/batch.sql <<EOF
+    DROP DATABASE IF EXISTS ${CLUSTER_ID}_master ;
+    USE DATABASE mysql;
+    DROP USER IF EXISTS '${CLUSTER_ID}' ;
+EOF
+    cat > /tmp/batch.js <<EOF
+    db.dropDatabase()
+EOF
+fi
 
 cat /tmp/batch.sql
 cat /tmp/batch.js
-
 mysql -h ${DB_HOST} -u ${DB_MASTERUSERNAME} -p${DB_MASTERPASSWORD} < /tmp/batch.sql
 mongo ${MONGO_HOST}/${CLUSTER_ID} --username ${MONGO_MASTERUSERNAME} --password ${MONGO_MASTERPASSWORD} --authenticationDatabase admin /tmp/batch.js


### PR DESCRIPTION
Prior to this change, when a cluster is terminated, the mysql and the mongo database created for the cluster doesn't get dropped and the user created for the cluster doesn't get deleted.

This PR would enable the cleanup of the database and the user created for the cluster.